### PR TITLE
Alter key match parameter to exclude extra results

### DIFF
--- a/covid19_domains.ps1
+++ b/covid19_domains.ps1
@@ -64,7 +64,7 @@ $dateLatest = [System.DateTime]::MinValue
 $covidLatest = "none"
 foreach ($c in $xmlroot.Contents)
 {
-    if ($c.Key -match "covid.*")
+    if ($c.Key -match "covid-.*")
     {
         $tmpCoName = $c.Key
         $tmpDateStr = $c.LastModified


### PR DESCRIPTION
Hi, 

I noticed this morning that after our scheduled 2am run, our output file was empty.

Running the file I noticed that we were flagging the wrong file for retreival:

` PS H:\> C:\temp\logrhythm_covid.ps1
Found latest covid domain file: 05/12/2020 00:21:38: covid19_blacklisted_hosts.txt 
`
A quick debug run showed that there are only a couple of files showing up in the initial pattern match that we don't want to catch, and they were easily excluded by adding another character to the pattern match query.  

``` covid-20200309 - 2020-03-16T16:52:30.000Z - 03/17/2020 00:52:30
covid-20200310 - 2020-03-16T16:52:31.000Z - 03/17/2020 00:52:31
covid-20200311 - 2020-03-16T16:52:33.000Z - 03/17/2020 00:52:33
covid-20200312 - 2020-03-16T16:52:32.000Z - 03/17/2020 00:52:32
covid-20200313 - 2020-03-16T16:52:31.000Z - 03/17/2020 00:52:31
covid-20200314 - 2020-03-16T16:52:32.000Z - 03/17/2020 00:52:32
covid-20200315 - 2020-03-16T16:52:32.000Z - 03/17/2020 00:52:32
covid-20200316 - 2020-03-17T13:11:52.000Z - 03/17/2020 21:11:52
covid-20200317 - 2020-03-18T13:03:44.000Z - 03/18/2020 21:03:44
covid-20200318 - 2020-03-19T12:38:00.000Z - 03/19/2020 20:38:00
covid-20200319 - 2020-03-20T13:54:17.000Z - 03/20/2020 21:54:17
covid-20200320 - 2020-03-21T13:26:05.000Z - 03/21/2020 21:26:05
covid-20200321 - 2020-03-22T19:23:04.000Z - 03/23/2020 03:23:04
covid-20200322 - 2020-03-23T13:35:45.000Z - 03/23/2020 21:35:45
covid-20200323 - 2020-03-24T13:27:26.000Z - 03/24/2020 21:27:26
covid-20200324 - 2020-03-25T13:11:36.000Z - 03/25/2020 21:11:36
covid-20200325 - 2020-03-26T12:28:24.000Z - 03/26/2020 20:28:24
covid-20200326 - 2020-03-27T11:56:45.000Z - 03/27/2020 19:56:45
covid-20200327 - 2020-03-28T13:07:08.000Z - 03/28/2020 21:07:08
covid-20200328 - 2020-03-29T12:45:07.000Z - 03/29/2020 20:45:07
covid-20200329 - 2020-03-30T12:48:22.000Z - 03/30/2020 20:48:22
covid-20200330 - 2020-03-31T13:06:04.000Z - 03/31/2020 21:06:04
covid-20200331 - 2020-04-01T13:04:41.000Z - 04/01/2020 21:04:41
covid-20200401 - 2020-04-02T12:26:11.000Z - 04/02/2020 20:26:11
covid-20200402 - 2020-04-03T12:22:51.000Z - 04/03/2020 20:22:51
covid-20200403 - 2020-04-04T13:11:27.000Z - 04/04/2020 21:11:27
covid-20200404 - 2020-04-05T12:38:17.000Z - 04/05/2020 20:38:17
covid-20200405 - 2020-04-06T13:02:13.000Z - 04/06/2020 21:02:13
covid-20200406 - 2020-04-07T13:57:17.000Z - 04/07/2020 21:57:17
covid-20200407 - 2020-04-09T01:21:30.000Z - 04/09/2020 09:21:30
covid-20200408 - 2020-04-09T14:45:10.000Z - 04/09/2020 22:45:10
covid-20200409 - 2020-04-10T13:06:58.000Z - 04/10/2020 21:06:58
covid-20200410 - 2020-04-11T16:40:39.000Z - 04/12/2020 00:40:39
covid-20200411 - 2020-04-12T13:52:51.000Z - 04/12/2020 21:52:51
covid-20200412 - 2020-04-13T13:14:50.000Z - 04/13/2020 21:14:50
covid-20200413 - 2020-04-14T13:58:14.000Z - 04/14/2020 21:58:14
covid-20200414 - 2020-04-15T12:05:21.000Z - 04/15/2020 20:05:21
covid-20200415 - 2020-04-16T14:25:30.000Z - 04/16/2020 22:25:30
covid-20200416 - 2020-04-17T12:58:21.000Z - 04/17/2020 20:58:21
covid-20200417 - 2020-04-18T13:40:34.000Z - 04/18/2020 21:40:34
covid-20200418 - 2020-04-19T14:44:28.000Z - 04/19/2020 22:44:28
covid-20200419 - 2020-04-20T19:32:14.000Z - 04/21/2020 03:32:14
covid-20200420 - 2020-04-21T15:51:08.000Z - 04/21/2020 23:51:08
covid-20200421 - 2020-04-22T12:41:52.000Z - 04/22/2020 20:41:52
covid-20200422 - 2020-04-23T13:17:36.000Z - 04/23/2020 21:17:36
covid-20200423 - 2020-04-24T12:50:23.000Z - 04/24/2020 20:50:23
covid-20200424 - 2020-04-25T13:50:55.000Z - 04/25/2020 21:50:55
covid-20200425 - 2020-04-26T14:04:54.000Z - 04/26/2020 22:04:54
covid-20200426 - 2020-04-27T13:18:49.000Z - 04/27/2020 21:18:49
covid-20200427 - 2020-04-28T13:52:20.000Z - 04/28/2020 21:52:20
covid-20200428 - 2020-04-29T14:27:52.000Z - 04/29/2020 22:27:52
covid-20200429 - 2020-05-01T13:16:29.000Z - 05/01/2020 21:16:29
covid-20200430 - 2020-05-01T13:16:28.000Z - 05/01/2020 21:16:28
covid-20200501 - 2020-05-02T15:41:27.000Z - 05/02/2020 23:41:27
covid-20200502 - 2020-05-03T19:04:58.000Z - 05/04/2020 03:04:58
covid-20200503 - 2020-05-04T17:02:51.000Z - 05/05/2020 01:02:51
covid-20200504 - 2020-05-06T13:31:18.000Z - 05/06/2020 21:31:18
covid-20200505 - 2020-05-06T13:30:27.000Z - 05/06/2020 21:30:27
covid-20200506 - 2020-05-07T14:49:48.000Z - 05/07/2020 22:49:48
covid-20200507 - 2020-05-08T13:51:30.000Z - 05/08/2020 21:51:30
covid-20200508 - 2020-05-09T13:05:01.000Z - 05/09/2020 21:05:01
covid-20200509 - 2020-05-10T16:57:04.000Z - 05/11/2020 00:57:04
covid-20200510 - 2020-05-11T15:17:35.000Z - 05/11/2020 23:17:35
covid19_blacklist.html - 2020-05-08T23:11:44.000Z - 05/09/2020 07:11:44
covid19_blacklisted_hosts.txt - 2020-05-11T16:21:38.000Z - 05/12/2020 00:21:38 
```
I've altered our copy of the script to account for this and now we're back to business as expected!

It's a simple fix but I thought it worth sharing ASAP.

Cheers